### PR TITLE
Fix simulated annealing. Update repl to use sim anneal + greedy optimization

### DIFF
--- a/core/src/optimization.rs
+++ b/core/src/optimization.rs
@@ -25,9 +25,6 @@ pub struct GreedyAlternativeD3;
 #[derive(Debug, Clone)]
 pub struct SimulatedAnnealing;
 
-#[derive(Debug, Clone)]
-pub struct SimulatedAnnealingDepth2;
-
 #[derive(Clone, Copy, Debug)]
 pub enum OptimizationMethod {
     Greedy,
@@ -89,14 +86,8 @@ impl OptimizeLayout for GreedyAlternativeD3 {
     }
 }
 
-// impl OptimizeLayout<3> for SimulatedAnnealing {
+// impl OptimizeLayout for SimulatedAnnealing {
 //     fn optimize(a: &Analyzer, layout: Layout, [initial_temperature, cooling_rate, max_iterations]: [f64; 3]) -> (Layout, i64) {
 //         a.annealing_improve(layout, initial_temperature, cooling_rate, max_iterations as usize)
-//     }
-// }
-
-// impl OptimizeLayout<3> for SimulatedAnnealingDepth2 {
-//     fn optimize(a: &Analyzer, layout: Layout, [initial_temperature, cooling_rate, max_iterations]: [f64; 3]) -> (Layout, i64) {
-//         a.annealing_depth2_improve(layout, initial_temperature, cooling_rate, max_iterations as usize)
 //     }
 // }

--- a/core/src/simulated_annealing.rs
+++ b/core/src/simulated_annealing.rs
@@ -5,6 +5,7 @@ use crate::{
     cached_layout::CachedLayout,
     layout::{Layout, PosPair},
 };
+// use plotters::prelude::*;
 
 impl Analyzer {
     pub fn annealing_improve(
@@ -12,75 +13,102 @@ impl Analyzer {
         layout: Layout,
         pins: &[usize],
         initial_temperature: f64,
-        cooling_rate: f64,
+        final_temperature: f64,
         max_iterations: usize,
     ) -> (Layout, i64) {
+        assert!(
+            initial_temperature > final_temperature,
+            "Final temperature must be less than initial temperature"
+        );
+        assert!(
+            initial_temperature > 0.0,
+            "Initial temperature must be positive"
+        );
+        assert!(
+            final_temperature > 0.0,
+            "Final temperature must be positive"
+        );
+
         let mut cache = self.cached_layout(layout, pins);
         let mut rng = WyRand::new();
+        let mut best = cache.clone();
 
-        let mut current_score = self.score_cache(&cache);
+        let mut best_score = self.score_cache(&cache);
+        let mut current_score = best_score;
+        let mut worst_score = current_score;
         let mut temperature = initial_temperature;
+
+        // Calculate cooling rate based on final temperature
+        let cooling_rate =
+            (final_temperature / initial_temperature).powf(1.0 / max_iterations as f64);
+        assert!(cooling_rate < 1.0, "Cooling rate must be < 1.0");
+
+        // let mut scores = Vec::<i64>::new();
 
         for _ in 0..max_iterations {
             let swap = random_swap(&cache, &mut rng);
 
+            // Test the swap
             cache.swap(swap);
-            let new_score = self.score_cached_swap(&mut cache, swap);
+            self.update_cache(&mut cache, swap);
+            let new_score = self.score_cache(&cache);
 
-            let ap = acceptance_probability(current_score, new_score, temperature);
+            if new_score < worst_score {
+                worst_score = new_score;
+            }
+            if new_score > best_score {
+                best_score = new_score;
+                best = cache.clone();
+            }
+
+            // Odds we take this swap
+            let ap = acceptance_probability(current_score, new_score, worst_score, temperature);
 
             if ap > f64::random(&mut rng) {
-                self.update_cache(&mut cache, swap);
                 current_score = new_score;
             } else {
+                // Undo the swap
                 cache.swap(swap);
+                self.update_cache(&mut cache, swap);
             }
+            // scores.push(current_score);
 
             temperature *= cooling_rate;
         }
+        // plot_line_chart(scores).expect("Failed to plot line chart");
 
-        (cache.into(), current_score)
-    }
-
-    pub fn annealing_depth2_improve(
-        &self,
-        layout: Layout,
-        pins: &[usize],
-        initial_temperature: f64,
-        cooling_rate: f64,
-        max_iterations: usize,
-    ) -> (Layout, i64) {
-        let mut cache = self.cached_layout(layout, pins);
-        let mut rng = WyRand::new();
-
-        let mut current_score = self.score_cache(&cache);
-        let mut temperature = initial_temperature;
-
-        for _ in 0..max_iterations {
-            let [swap1, swap2] = random_swap2(&cache, &mut rng);
-
-            cache.swap(swap1);
-            self.update_cache(&mut cache, swap1);
-            cache.swap(swap2);
-            let new_score = self.score_cached_swap(&mut cache, swap2);
-
-            let ap = acceptance_probability(current_score, new_score, temperature);
-
-            if ap > f64::random(&mut rng) {
-                self.update_cache(&mut cache, swap2);
-                current_score = new_score;
-            } else {
-                cache.swap(swap2);
-                cache.swap(swap1);
-                self.update_cache(&mut cache, swap1);
-            }
-
-            temperature *= cooling_rate;
-        }
-
-        (cache.into(), current_score)
+        (best.into(), best_score)
     }
 }
+
+// fn plot_line_chart(data: Vec<i64>) -> Result<(), Box<dyn std::error::Error>> {
+//     // Create a drawing area with the specified dimensions
+//     let root = BitMapBackend::new("line_plot.png", (800, 600)).into_drawing_area();
+//     root.fill(&WHITE)?;
+
+//     // Create a chart builder
+//     let mut chart = ChartBuilder::on(&root)
+//         .caption("Line Plot", ("sans-serif", 50))
+//         .margin(5)
+//         .x_label_area_size(40)
+//         .y_label_area_size(40)
+//         .build_cartesian_2d(
+//             0..data.len() as i64,
+//             *data.iter().min().unwrap()..*data.iter().max().unwrap(),
+//         )?;
+
+//     // Draw a line plot
+//     chart.draw_series(LineSeries::new(
+//         data.iter().enumerate().map(|(x, &y)| (x as i64, y)),
+//         &RED,
+//     ))?;
+
+//     // Add a grid and labels for x and y axes
+//     chart.configure_mesh().draw()?;
+
+//     // Save the plot
+//     Ok(())
+// }
 
 #[inline]
 fn random_swap(cache: &CachedLayout, rng: &mut WyRand) -> PosPair {
@@ -88,19 +116,69 @@ fn random_swap(cache: &CachedLayout, rng: &mut WyRand) -> PosPair {
 }
 
 #[inline]
-fn random_swap2(cache: &CachedLayout, rng: &mut WyRand) -> [PosPair; 2] {
-    [random_swap(cache, rng), random_swap(cache, rng)]
-}
-
-#[inline]
-fn acceptance_probability(current_score: i64, new_score: i64, temperature: f64) -> f64 {
+fn acceptance_probability(
+    current_score: i64,
+    new_score: i64,
+    worst_score: i64,
+    temperature: f64,
+) -> f64 {
+    // Good scores are less negative (greater) than bad scores
+    // ie. qwerty: -721853925651
+    //     sturdy: -169325667674
     if new_score > current_score {
+        // Always take the new layout if it's better
         1.0
     } else {
-        ((new_score - current_score) as f64 / temperature).exp()
+        // If worse, odds of taking new layout vary with temperature
+        // Use worst score to normalize the objective function (or temperature values don't make sense)
+        (((new_score - current_score) as f64 / worst_score.abs() as f64) / temperature).exp()
     }
-    // println!(
-    //     "diff: {:<15} temp: {temperature:<20} ap: {ap}",
-    //     new_score - current_score
-    // );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::Data;
+    use crate::weights::dummy_weights;
+
+    #[test]
+    fn test_acceptance_probability() {
+        // New score is better
+        let current_score = -100;
+        let new_score = -90;
+        let worst_score = -100;
+        let temperature = 10.0;
+        let ap = acceptance_probability(current_score, new_score, worst_score, temperature);
+        assert_eq!(ap, 1.0);
+
+        // new score is worse
+        let current_score = -90;
+        let new_score = -100;
+        let worst_score = -100;
+        let temperature = 10.0;
+        let ap = acceptance_probability(current_score, new_score, worst_score, temperature);
+        let target = (-0.01f64).exp();
+        assert_eq!(ap, target);
+    }
+
+    #[test]
+    fn test_annealing_improve() {
+        let data = Data::load("../data/english.json").expect("this should exist");
+        let weights = dummy_weights();
+        let analyzer = Analyzer::new(data, weights);
+        let layout = Layout::load(format!("../layouts/sturdy.dof"))
+            .expect("this layout is valid and exists, soooo");
+        let pins = vec![];
+        let initial_temperature = 0.0001;
+        let max_iterations = 1000;
+
+        let qwerty_score = analyzer.score(&layout);
+        let (new_layout, score) =
+            analyzer.annealing_improve(layout, &pins, initial_temperature, 0.95, max_iterations);
+        assert_eq!(score, analyzer.score(&new_layout));
+
+        // After 1000 iterations, this better have made it better
+        assert!(score > qwerty_score);
+    }
 }

--- a/repl/src/lib.rs
+++ b/repl/src/lib.rs
@@ -134,9 +134,12 @@ impl Repl {
             .into_par_iter()
             .map(|_| {
                 let l = layout.random_with_pins(&pins);
-                let res = self.a.alternative_d3(l, &pins);
+                // let res = self.a.alternative_d3(l, &pins);
                 // self.a.greedy_depth2_improve(l)
                 // .annealing_improve(starting_layout, 20_500_000_000_000.0, 0.987, 5000)
+                let (annealed_layout, _) =
+                    self.a.annealing_improve(l, &pins, 10.0, 1E-5, 10_000_000);
+                let res = self.a.alternative_d3(annealed_layout, &pins);
 
                 iteration.fetch_add(1, Ordering::Relaxed);
 


### PR DESCRIPTION
I was able to fix a few issues with the existing implementation and get simulated annealing working. It seems to do a much better job of quickly exploring the space than greedy alone, but after playing around with the settings I got the  best results from running both annealing & greedy search. 10M iterations for the annealing seems to be the sweet spot. Above that seems to have diminishing returns.

Pretty happy with the results. It seems to find the global optimum 5-10% of the time (vs ~1% for greedy_alt_d3 or simulated annealing alone), and it's also 2-3x faster. On my M3 macbook air with 32 keys no pins it takes 75-90s to generate 100 layouts, vs 200-220s for greedy alone. I updated the repl to use my settings. Give it a go and let me know what you think.

I also left the plotters code I used to tune the temperatures commented out, but can clean it up if necessary. It produces plots like this:
![line_plot](https://github.com/user-attachments/assets/730b4565-62cf-4499-9660-679a0e6c1ee7)

